### PR TITLE
Upgrade to AWS v 3 (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ MIT Licensed. See LICENSE for full details.
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/api_gateway/README.md
+++ b/triggers/api_gateway/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by API Gateways
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/api_gateway/versions.tf
+++ b/triggers/api_gateway/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/triggers/cloudwatch_event_schedule/README.md
+++ b/triggers/cloudwatch_event_schedule/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by Cloudwatch Event Schedule
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/cloudwatch_event_schedule/versions.tf
+++ b/triggers/cloudwatch_event_schedule/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/triggers/cloudwatch_event_trigger/README.md
+++ b/triggers/cloudwatch_event_trigger/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by Cloudwatch Event Trigger
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/cloudwatch_event_trigger/versions.tf
+++ b/triggers/cloudwatch_event_trigger/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/triggers/cloudwatch_logs/README.md
+++ b/triggers/cloudwatch_logs/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by Cloudwatch logs
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/cloudwatch_logs/versions.tf
+++ b/triggers/cloudwatch_logs/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/triggers/cognito_idp/README.md
+++ b/triggers/cognito_idp/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by Cognito IDP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/cognito_idp/versions.tf
+++ b/triggers/cognito_idp/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/triggers/sqs/README.md
+++ b/triggers/sqs/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by SQS and optionally subscribe to SNS topics
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/sqs/versions.tf
+++ b/triggers/sqs/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/triggers/step_function/README.md
+++ b/triggers/step_function/README.md
@@ -8,13 +8,13 @@ Allow this lambda to be triggered by Step functions
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/triggers/step_function/versions.tf
+++ b/triggers/step_function/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
   experiments = [variable_validation]
 }


### PR DESCRIPTION
* Upgrade to most recent 2.X version

* Upgrade to version 3.0

* Set required providers aws to ~> 3.0

* Custom variable validation can now be used by default, without enabling an experiment.

* update terraform-docs command

* terraform-docs to README.md

* Fix tests

Co-authored-by: Puneeth Nanjundaswamy <puneeth.nanjundaswamy@comtravo.com>